### PR TITLE
refactor: change name to github user name

### DIFF
--- a/data.json
+++ b/data.json
@@ -636,7 +636,7 @@
     "issueNumber": 359
   },
   {
-    "name": "Tom Schmelzer",
+    "name": "schmelto",
     "githubUsername": "schmelto",
     "imageUrl": "https://user-images.githubusercontent.com/30869493/108380804-7ea4d000-7207-11eb-8f3e-2d00b21d1456.png",
     "issueNumber": 373


### PR DESCRIPTION
Change the name to GitHub user name to be more consistent through the platform