### PR TITLE
fix: Update Discord invitation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,4 +2,4 @@
 
 Please feel free to raise an [issue](https://github.com/EddieJaoudeCommunity/awesome-github-profiles/issues) with ideas / suggestions or other GitHub profiles you think are awesome!
 
-Join the conversation in our [Discord community](https://discord.com/invite/jZQs6Wu)
+Join the conversation in our [Discord community](http://discord.eddiehub.org)


### PR DESCRIPTION
Things added/changed:

- Update Discord invitation to `http://discord.eddiehub.org`.
