### PR TITLE
fix: use `MIT` in the `package.json` file

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/EddieHubCommunity/awesome-github-profiles/issues"
   },


### PR DESCRIPTION
Things added/changed:

- Use the `MIT` in the `package.json` file.
  - Closes #858.
