### PR TITLE
fix(tools): workflow

### DIFF
--- a/.github/workflows/prettier-lint-check.yml
+++ b/.github/workflows/prettier-lint-check.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        
+
       - name: Load Node.js
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/prettier-lint-check.yml
+++ b/.github/workflows/prettier-lint-check.yml
@@ -23,12 +23,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          # Make sure the actual branch is checked out when running on pull requests
-          ref: ${{ github.head_ref }}
-          # This is important to fetch the changes to the previous commit
-          fetch-depth: 0
-
+        
       - name: Load Node.js
         uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
The parameters to the checkout-node action are breaking the prettier workflow for forks.

This shouldn't be necessary anyway - I've been running this same workflow on my own projects without these parameters and have had no issues.